### PR TITLE
Fix slate dom node resolution error

### DIFF
--- a/src/components/ui/inline-combobox.tsx
+++ b/src/components/ui/inline-combobox.tsx
@@ -310,6 +310,7 @@ const InlineComboboxItem = ({
   const { filter, removeInput } = React.useContext(InlineComboboxContext);
 
   const store = useComboboxContext()!;
+  const editor = useEditorRef();
 
   // Optimization: Do not subscribe to value if filter is false
   const search = filter && store.useState('value');
@@ -326,8 +327,9 @@ const InlineComboboxItem = ({
     <ComboboxItem
       className={cn(comboboxItemVariants(), className)}
       onClick={(event) => {
-        removeInput(focusEditor);
+        removeInput(false);
         onClick?.(event);
+        if (focusEditor) editor.tf.focus();
       }}
       {...props}
     />

--- a/src/components/ui/slash-node.tsx
+++ b/src/components/ui/slash-node.tsx
@@ -107,6 +107,7 @@ export function SlashInputElement(
               <InlineComboboxItem
                 key={item.item.id}
                 value={item.item.textNoTashkeel}
+                focusEditor={false}
                 onClick={() =>
                   item.item.onSelect(editor, item.item.textTashkeel, "#16a34a")
                 }


### PR DESCRIPTION
Fix 'Cannot resolve a DOM node from Slate node' error when inserting aya by adjusting editor focus timing.

The error occurred because the editor attempted to focus a DOM node that was being removed by the combobox before the new content was fully rendered, leading to a mismatch between the Slate state and the DOM.

---
<a href="https://cursor.com/background-agent?bcId=bc-18c776dc-fe84-4a25-98bf-228773df1f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18c776dc-fe84-4a25-98bf-228773df1f81">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

