### PR TITLE
Integrate Quran Foundation content & user sync (search, bookmarks, sync queue, UI)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,7 @@
 VITE_DATA_URL=
+VITE_USE_QF_CONTENT_API=false
+
+# Quran Foundation credentials (from hackathon dashboard/email)
+VITE_QF_CLIENT_ID=
+VITE_QF_CLIENT_SECRET=
+VITE_QF_ENDPOINT=

--- a/README.md
+++ b/README.md
@@ -60,3 +60,20 @@ yarn build
 2. **إدراج آيات قرآنية**:ضع مسافة ثم اكتب `/` متبوعًا ببداية الآية التي تريد إدراجها
 3. **تنسيق النص**: استخدم شريط الأدوات لتنسيق النص
 
+
+## وضع الهاكاثون (تكامل Quran Foundation)
+
+يمكنك الإبقاء على التطبيق محليًا بالكامل، أو تفعيل تكامل API كالتالي:
+
+```bash
+cp .env.template .env
+```
+
+ثم حدّث المتغيرات:
+
+- `VITE_USE_QF_CONTENT_API=true` لتفعيل البحث عبر Content API.
+- `VITE_QF_ENDPOINT`: ضع الـ End-Point الذي وصلك من الهاكاثون.
+- `VITE_QF_CLIENT_ID`: ضع Client ID.
+- `VITE_QF_CLIENT_SECRET`: ضع Client Secret.
+
+عند عدم تفعيل بيانات User API سيظل التطبيق يعمل محليًا فقط (Local-first).

--- a/docs/quran-hackathon-gap-analysis.md
+++ b/docs/quran-hackathon-gap-analysis.md
@@ -1,0 +1,152 @@
+# Kamil × Quran Foundation Hackathon (Provision Launch)
+
+_Date analyzed: April 27, 2026_
+
+## 1) What the hackathon **requires** (non-negotiable)
+
+From the official hackathon page and terms:
+
+1. Use **at least one Content API** from Quran Foundation (or Quran MCP).
+2. Use **at least one User API** from Quran Foundation.
+3. Submit by **May 20, 2026** (early Dhu al-Hijjah 1447).
+4. Submission package must include:
+   - project title,
+   - team members,
+   - short + detailed description,
+   - live demo link,
+   - GitHub repo (if available),
+   - 2–3 minute demo video,
+   - explanation of API usage.
+
+## 2) Judging priorities (where to optimize)
+
+Scoring is out of 100:
+- **30** Impact on Quran Engagement
+- **20** Product Quality & UX
+- **20** Technical Execution
+- **15** Innovation & Creativity
+- **15** Effective Use of APIs
+
+For Kamil, this means: protect your strong Arabic-first writing UX, then add meaningful Quran engagement loops and deep API usage evidence.
+
+## 3) Your app identity today (what to preserve)
+
+Current Kamil strengths from this codebase:
+- Arabic writing/editor-first experience with inline ayah insertion.
+- Local persistence via **IndexedDB (Dexie)**.
+- Offline-style workflow and export features.
+
+Keep this identity: **"local-first Quran writing studio"**.
+
+## 4) Gap analysis against hackathon requirements
+
+### Already aligned
+- Quran-centered use case (writing with ayat).
+- Good UX foundation (editor + quick insertion + exports).
+- Technical baseline is solid.
+
+### Missing / risky for eligibility
+- Current ayah source is loaded from `VITE_DATA_URL`; hackathon requires Quran Foundation Content API (or Quran MCP) usage.
+- No explicit Quran Foundation User API integration (bookmarks, collections, streak, goals, etc.).
+
+Without User API usage, project can fail eligibility screening.
+
+## 5) What Kamil needs to add (while staying local-first)
+
+## A. Required integration architecture (recommended)
+
+Implement a **dual-layer model**:
+- **Local-first layer (default):** everything works from IndexedDB immediately.
+- **Connected sync layer (optional):** if user signs in, sync selected entities with Quran Foundation User APIs.
+
+This keeps Kamil local-first while satisfying technical requirements.
+
+## B. Minimum feature set to be eligible + competitive
+
+### 1) Content API / MCP integration (required)
+Pick at least one, but preferably 2+ for stronger API score:
+- Verse search/retrieval from Quran Foundation Quran APIs or Quran MCP.
+- Optional: tafsir or translation fetch for inserted ayah.
+
+Kamil UX fit:
+- `/` command continues to work.
+- If online: query Quran Foundation API/MCP for suggestions.
+- If offline: fallback to local cached data.
+
+### 2) User API integration (required)
+Pick at least one user capability, ideally 2:
+- **Bookmarks** for ayat used in notes.
+- **Collections** mapped to notebook/page folders.
+- Optional: **Streak tracking** for daily writing/reflection habit.
+
+Kamil UX fit:
+- "Save to Quran account" toggle per item.
+- Local object is created first, then background sync when authenticated.
+
+## C. Product features that maximize judging points
+
+### Impact (30 pts)
+Add habit loops:
+- Daily reflection prompt from selected surah/goal.
+- "Resume where you left" writing workflow.
+
+### UX (20 pts)
+- Keep Arabic-first keyboard flow.
+- Show clear local/offline/synced badges.
+- One-click export/share of reflection notes.
+
+### Technical execution (20 pts)
+- Conflict resolution strategy (local vs remote updates).
+- Retry queue for failed sync operations.
+- Deterministic IDs and timestamps.
+
+### Innovation (15 pts)
+- "Local-first spiritual journaling": privacy-first + optional cloud sync.
+- Smart context insertion (ayah + quick tafsir + translation card).
+
+### API use (15 pts)
+- Demonstrate multiple endpoints and meaningful usage, not just one demo call.
+- In demo video, explicitly show where each API powers user value.
+
+## 6) Suggested implementation plan (fast path)
+
+### Phase 1 (Eligibility lock)
+1. Integrate one Content API flow for ayah lookup.
+2. Integrate one User API flow (bookmark OR collection).
+3. Add API usage logging/telemetry panel for demo evidence.
+
+### Phase 2 (Score boost)
+4. Add streak/goals or reflections posting.
+5. Add offline cache + background sync queue.
+6. Add polished "Sync Status" UI.
+
+### Phase 3 (Submission readiness)
+7. Record 2–3 min demo video script:
+   - local write flow,
+   - Quran API-powered insertion,
+   - user sync (bookmark/collection),
+   - offline fallback.
+8. Prepare concise architecture diagram and API mapping table.
+
+## 7) Recommended submission positioning
+
+Use this positioning line in your submission:
+
+> **Kamil is a local-first Arabic Quran writing studio that protects focus and privacy offline, while optionally syncing Quran bookmarks, collections, and engagement data through Quran Foundation APIs.**
+
+This keeps your identity intact while clearly matching eligibility.
+
+## 8) Risks to avoid
+
+- Building only content retrieval and skipping User APIs (disqualification risk).
+- Building only "checkbox" API integration with no real UX impact (low API score).
+- Making the app cloud-dependent and losing local-first identity.
+
+## 9) Final checklist before submission
+
+- [ ] Uses Quran Foundation Content API or Quran MCP in real feature flow.
+- [ ] Uses Quran Foundation User API in real feature flow.
+- [ ] Works local-first when offline.
+- [ ] Clear explanation of where APIs are used.
+- [ ] Demo video shows both user value and technical integration.
+- [ ] Submission includes all required artifacts.

--- a/src/components/SyncStatusBadge.tsx
+++ b/src/components/SyncStatusBadge.tsx
@@ -1,0 +1,44 @@
+import { db } from "@/lib/db";
+import { flushSyncQueue, hasUserApiCredentials } from "@/lib/qf-sync";
+import { useLiveQuery } from "dexie-react-hooks";
+import { CloudOff, CloudUpload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export function SyncStatusBadge() {
+  const pending = useLiveQuery(
+    () => db.syncQueue.where("status").equals("pending").count(),
+    [],
+    0
+  );
+  const failed = useLiveQuery(
+    () => db.syncQueue.where("status").equals("failed").count(),
+    [],
+    0
+  );
+
+  if (!hasUserApiCredentials()) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <CloudOff className="h-3.5 w-3.5" />
+        مزامنة سحابية غير مفعلة
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-xs">
+      <div className="flex items-center gap-1 text-muted-foreground">
+        <CloudUpload className="h-3.5 w-3.5" />
+        {pending} انتظار / {failed} فشل
+      </div>
+      <Button
+        size="sm"
+        variant="outline"
+        className="h-6 px-2 text-xs"
+        onClick={() => void flushSyncQueue()}
+      >
+        مزامنة الآن
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/slash-node.tsx
+++ b/src/components/ui/slash-node.tsx
@@ -4,7 +4,9 @@ import * as React from "react";
 import type { PlateEditor, PlateElementProps } from "platejs/react";
 import { type TComboboxInputElement } from "platejs";
 import { PlateElement } from "platejs/react";
-import { useFuzzySearchList, Highlight } from '@nozbe/microfuzz/react'
+import { useFuzzySearchList, Highlight } from "@nozbe/microfuzz/react";
+import { BookmarkPlus } from "lucide-react";
+import { toast } from "sonner";
 
 import {
   InlineCombobox,
@@ -14,25 +16,39 @@ import {
   InlineComboboxItem,
 } from "./inline-combobox";
 import { KEYS } from "platejs";
+import {
+  type QuranVerseResult,
+  searchQuranFoundationVerses,
+  shouldUseQfContentApi,
+} from "@/lib/quran-foundation";
+import { db } from "@/lib/db";
+import {
+  enqueueBookmarkSync,
+  flushSyncQueue,
+  hasUserApiCredentials,
+} from "@/lib/qf-sync";
 
-type Group = {
-  id: number;
-  surah: string;
-  aya: number;
-  textNoTashkeel: string;
-  textMinTashkeel: string;
-  textTashkeel: string;
+type Group = QuranVerseResult & {
   onSelect: (editor: PlateEditor, value: string, color?: string) => void;
 };
 
-const loadQuran = async () => {
+const loadQuran = async (): Promise<QuranVerseResult[]> => {
   try {
     const response = await fetch(import.meta.env.VITE_DATA_URL);
     if (!response.ok) {
       console.error("Failed to load quran data");
       return [];
     }
-    return await response.json();
+
+    const data = await response.json();
+
+    return (data as Array<Omit<QuranVerseResult, "id" | "source">>).map(
+      (item, index) => ({
+        ...item,
+        id: `local-${index}`,
+        source: "local",
+      })
+    );
   } catch (error) {
     console.error("Failed to load quran data", error);
     return [];
@@ -41,15 +57,7 @@ const loadQuran = async () => {
 
 const quran = await loadQuran();
 
-interface Aya {
-  surah: string;
-  aya: number;
-  textNoTashkeel: string;
-  textMinTashkeel: string;
-  textTashkeel: string;
-}
-
-const groups: Group[] = quran.map((item: Aya) => ({
+const groups: Group[] = quran.map((item) => ({
   ...item,
   onSelect: (editor: PlateEditor, value: string, color = "#16a34a") => {
     const fontSize = editor.api.marks()?.[KEYS.fontSize];
@@ -57,20 +65,29 @@ const groups: Group[] = quran.map((item: Aya) => ({
     editor.tf.addMarks({ fontSize });
     editor.tf.insertText(` ﴿${value}﴾ [${item.surah} ${item.aya}] `);
     editor.tf.removeMark("color");
-
   },
 }));
 
-
-
+const toSelectableGroup = (item: QuranVerseResult): Group => ({
+  ...item,
+  onSelect: (editor: PlateEditor, value: string, color = "#16a34a") => {
+    const fontSize = editor.api.marks()?.[KEYS.fontSize];
+    editor.tf.addMarks({ color });
+    editor.tf.addMarks({ fontSize });
+    editor.tf.insertText(` ﴿${value}﴾ [${item.surah} ${item.aya}] `);
+    editor.tf.removeMark("color");
+  },
+});
 
 export function SlashInputElement(
   props: PlateElementProps<TComboboxInputElement>
 ) {
   const { editor, element } = props;
   const [value, setValue] = React.useState("");
+  const [remoteResults, setRemoteResults] = React.useState<Group[]>([]);
   const fontSize = editor.api.marks()?.[KEYS.fontSize];
-  const filteredResults = useFuzzySearchList({
+
+  const filteredLocalResults = useFuzzySearchList({
     list: groups,
     queryText: value,
     getText: (item: Group) => [item.textNoTashkeel],
@@ -78,7 +95,74 @@ export function SlashInputElement(
       item,
       highlightRanges,
     }),
-  }).slice(0, 10); // Limit to 10 results
+  }).slice(0, 10);
+
+  React.useEffect(() => {
+    void flushSyncQueue();
+  }, []);
+
+  React.useEffect(() => {
+    if (!value || value.trim().length < 3 || !shouldUseQfContentApi()) {
+      setRemoteResults([]);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      searchQuranFoundationVerses(value, 6)
+        .then((result) => {
+          setRemoteResults(result.map(toSelectableGroup));
+        })
+        .catch(() => setRemoteResults([]));
+    }, 250);
+
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  const combinedResults = React.useMemo(() => {
+    const resultMap = new Map<string, Group>();
+
+    filteredLocalResults.forEach(({ item }) => {
+      resultMap.set(`${item.surah}:${item.aya}`, item);
+    });
+
+    remoteResults.forEach((item) => {
+      const key = `${item.surah}:${item.aya}`;
+      if (!resultMap.has(key)) {
+        resultMap.set(key, item);
+      }
+    });
+
+    return Array.from(resultMap.values()).slice(0, 10);
+  }, [filteredLocalResults, remoteResults]);
+
+  const handleBookmark = async (item: Group) => {
+    const verseKey = `${item.surah}:${item.aya}`;
+
+    await db.verseBookmarks.add({
+      verseKey,
+      surah: item.surah,
+      aya: item.aya,
+      ayahText: item.textTashkeel,
+      source: item.source,
+      createdAt: new Date().toISOString(),
+      syncedAt: undefined,
+    });
+
+    if (hasUserApiCredentials()) {
+      await enqueueBookmarkSync({
+        ayahText: item.textTashkeel,
+        surah: item.surah,
+        aya: item.aya,
+        verseKey,
+      });
+      await flushSyncQueue();
+      toast.success("تم حفظ الآية محلياً ومزامنتها مع الحساب");
+      return;
+    }
+
+    toast.success("تم حفظ الآية محلياً");
+  };
+
   return (
     <PlateElement {...props} as="span">
       <InlineCombobox
@@ -103,41 +187,56 @@ export function SlashInputElement(
         </span>
 
         <InlineComboboxContent className=" font-[amiri] divide-y divide-gray-100/50 p-0 shadow-lg rounded-xl border border-gray-200/60 bg-white">
-          {filteredResults.length === 0 ? (
+          {combinedResults.length === 0 ? (
             <InlineComboboxEmpty>
               <span className="block px-3 py-6 text-center text-gray-500 text-base">
                 لا يوجد نتائج
               </span>
             </InlineComboboxEmpty>
           ) : (
-            filteredResults.map(({ item, highlightRanges }) => (
+            combinedResults.map((item) => (
               <InlineComboboxItem
                 key={item.id}
                 value={item.textNoTashkeel}
                 focusEditor={false}
-                onClick={() =>
-                  item.onSelect(editor, item.textTashkeel, "#16a34a")
-                }
+                onClick={() => item.onSelect(editor, item.textTashkeel, "#16a34a")}
                 className="py-3 px-4 hover:bg-gray-50/80 transition-colors duration-200 cursor-pointer"
                 style={{
                   direction: "rtl",
                   fontSize: "1.2rem",
                 }}
               >
-                <span
-                  className="text-xs text-green-600 block mb-2"
-                  dir="ltr"
-                  style={{ fontSize: "1.2rem" }}
-                >
-                  {item.surah} {item.aya}
-                </span>
-                <span
-                  className="font-medium text-gray-900 leading-relaxed"
-                  dir="rtl"
-                  style={{ fontSize: "1.2rem" }}
-                >
-                  <Highlight text={item.textTashkeel} ranges={highlightRanges} />
-                </span>
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <span
+                      className="text-xs text-green-600 block mb-2"
+                      dir="ltr"
+                      style={{ fontSize: "1.2rem" }}
+                    >
+                      {item.surah} {item.aya}
+                      {item.source === "qf" ? " · API" : " · محلي"}
+                    </span>
+                    <span
+                      className="font-medium text-gray-900 leading-relaxed"
+                      dir="rtl"
+                      style={{ fontSize: "1.2rem" }}
+                    >
+                      <Highlight text={item.textTashkeel} ranges={[]} />
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    aria-label="حفظ الآية"
+                    className="rounded-md border p-1.5 hover:bg-green-50"
+                    onClick={(event) => {
+                      event.preventDefault();
+                      event.stopPropagation();
+                      void handleBookmark(item);
+                    }}
+                  >
+                    <BookmarkPlus className="h-4 w-4 text-green-700" />
+                  </button>
+                </div>
               </InlineComboboxItem>
             ))
           )}
@@ -146,4 +245,4 @@ export function SlashInputElement(
       {props.children}
     </PlateElement>
   );
-}   
+}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -22,6 +22,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState, useCallback, useRef } from "react";
 import { FileText, Download, SquarePen } from "lucide-react";
 import { SaveStatus, type SaveState } from "@/components/SaveStatus";
+import { SyncStatusBadge } from "@/components/SyncStatusBadge";
 import { exportToJSON, exportToHTML, exportToMarkdown, exportToPDF } from "@/lib/utils/export";
 import { debounce } from "@/lib/utils/debounce";
 
@@ -199,6 +200,7 @@ export default function SideBar() {
               {pageContent && (
                 <>
                   <SaveStatus state={saveState} />
+                  <SyncStatusBadge />
                 </>
               )}
             </div>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,5 @@
 import Dexie, { type EntityTable } from 'dexie';
 
-
 interface Page {
   id: number;
   name: string;
@@ -11,22 +10,46 @@ interface Page {
   isPinned?: boolean;
 }
 
+interface VerseBookmark {
+  id: number;
+  verseKey: string;
+  surah: string;
+  aya: number;
+  ayahText: string;
+  source: 'local' | 'qf';
+  createdAt: string;
+  syncedAt?: string;
+}
+
+interface SyncQueueItem {
+  id: number;
+  action: 'create_bookmark';
+  payload: string;
+  status: 'pending' | 'done' | 'failed';
+  createdAt: string;
+  lastError: string;
+}
+
 const db = new Dexie('PagesDatabase') as Dexie & {
-  pages: EntityTable<
-    Page,
-    'id' // primary key "id" (for the typings only)
-  >;
+  pages: EntityTable<Page, 'id'>;
+  verseBookmarks: EntityTable<VerseBookmark, 'id'>;
+  syncQueue: EntityTable<SyncQueueItem, 'id'>;
 };
 
 // Schema declaration:
 db.version(1).stores({
-  pages: '++id, name, description, content, createdAt, updatedAt' // primary key "id" (for the runtime!)
+  pages: '++id, name, description, content, createdAt, updatedAt'
 });
 
 db.version(2).stores({
   pages: '++id, name, description, content, createdAt, updatedAt, isPinned'
 });
 
+db.version(3).stores({
+  pages: '++id, name, description, content, createdAt, updatedAt, isPinned',
+  verseBookmarks: '++id, verseKey, surah, aya, source, createdAt, syncedAt',
+  syncQueue: '++id, action, status, createdAt'
+});
 
-export type { Page };
+export type { Page, VerseBookmark, SyncQueueItem };
 export { db };

--- a/src/lib/qf-sync.ts
+++ b/src/lib/qf-sync.ts
@@ -1,0 +1,78 @@
+import { db } from "@/lib/db";
+
+export type SyncAction = "create_bookmark";
+
+export interface SyncQueueItemPayload {
+  ayahText: string;
+  surah: string;
+  aya: number;
+  verseKey: string;
+}
+
+const QF_ENDPOINT =
+  import.meta.env.VITE_QF_ENDPOINT ||
+  import.meta.env.VITE_QF_USER_API_BASE ||
+  "";
+const QF_CLIENT_ID = import.meta.env.VITE_QF_CLIENT_ID || "";
+const QF_CLIENT_SECRET =
+  import.meta.env.VITE_QF_CLIENT_SECRET ||
+  import.meta.env.VITE_QF_USER_API_TOKEN ||
+  "";
+
+export function hasUserApiCredentials() {
+  return Boolean(QF_ENDPOINT && QF_CLIENT_ID && QF_CLIENT_SECRET);
+}
+
+export async function enqueueBookmarkSync(payload: SyncQueueItemPayload) {
+  await db.syncQueue.add({
+    action: "create_bookmark",
+    payload: JSON.stringify(payload),
+    status: "pending",
+    createdAt: new Date().toISOString(),
+    lastError: "",
+  });
+}
+
+async function pushBookmark(payload: SyncQueueItemPayload) {
+  const response = await fetch(`${QF_ENDPOINT}/bookmarks`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-client-id": QF_CLIENT_ID,
+      "x-client-secret": QF_CLIENT_SECRET,
+    },
+    body: JSON.stringify({
+      verse_key: payload.verseKey,
+      notes: payload.ayahText,
+      source: "kamil",
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`User API request failed with ${response.status}`);
+  }
+}
+
+export async function flushSyncQueue() {
+  if (!hasUserApiCredentials()) return;
+
+  const pendingItems = await db.syncQueue.where("status").equals("pending").toArray();
+
+  for (const item of pendingItems) {
+    try {
+      if (item.action === "create_bookmark") {
+        await pushBookmark(JSON.parse(item.payload));
+      }
+
+      await db.syncQueue.update(item.id, {
+        status: "done",
+        lastError: "",
+      });
+    } catch (error) {
+      await db.syncQueue.update(item.id, {
+        status: "failed",
+        lastError: error instanceof Error ? error.message : "Unknown sync error",
+      });
+    }
+  }
+}

--- a/src/lib/quran-foundation.ts
+++ b/src/lib/quran-foundation.ts
@@ -1,0 +1,84 @@
+export interface QuranVerseResult {
+  id: string;
+  surah: string;
+  aya: number;
+  textNoTashkeel: string;
+  textMinTashkeel: string;
+  textTashkeel: string;
+  source: "local" | "qf";
+}
+
+interface QfSearchResponse {
+  search?: {
+    results?: Array<{
+      verse_key?: string;
+      text?: string;
+      highlighted?: string;
+    }>;
+  };
+}
+
+const QF_ENDPOINT =
+  import.meta.env.VITE_QF_ENDPOINT ||
+  import.meta.env.VITE_QF_CONTENT_API_BASE ||
+  "https://api.quran.com/api/v4";
+
+const QF_CLIENT_ID = import.meta.env.VITE_QF_CLIENT_ID || "";
+const QF_CLIENT_SECRET = import.meta.env.VITE_QF_CLIENT_SECRET || "";
+
+const normalizeArabic = (input: string) =>
+  input
+    .replace(/[\u064B-\u0652\u0670]/g, "")
+    .replace(/[إأآا]/g, "ا")
+    .replace(/ى/g, "ي")
+    .trim();
+
+export async function searchQuranFoundationVerses(
+  query: string,
+  limit = 7
+): Promise<QuranVerseResult[]> {
+  if (!query.trim()) return [];
+
+  try {
+    const params = new URLSearchParams({
+      q: query,
+      size: String(limit),
+      language: "ar",
+    });
+
+    const response = await fetch(`${QF_ENDPOINT}/search?${params.toString()}`, {
+      headers: {
+        ...(QF_CLIENT_ID ? { "x-client-id": QF_CLIENT_ID } : {}),
+        ...(QF_CLIENT_SECRET ? { "x-client-secret": QF_CLIENT_SECRET } : {}),
+      },
+    });
+
+    if (!response.ok) return [];
+
+    const data = (await response.json()) as QfSearchResponse;
+    const results = data.search?.results ?? [];
+
+    return results
+      .map((item, index) => {
+        const [surah, aya] = (item.verse_key ?? "0:0").split(":");
+        const plainText = (item.text || item.highlighted || "").replace(/<[^>]+>/g, "");
+
+        return {
+          id: `qf-${item.verse_key ?? index}`,
+          surah,
+          aya: Number(aya || 0),
+          textNoTashkeel: normalizeArabic(plainText),
+          textMinTashkeel: plainText,
+          textTashkeel: plainText,
+          source: "qf" as const,
+        };
+      })
+      .filter((item) => item.aya > 0 && item.surah !== "0");
+  } catch {
+    return [];
+  }
+}
+
+export function shouldUseQfContentApi() {
+  return import.meta.env.VITE_USE_QF_CONTENT_API === "true";
+}


### PR DESCRIPTION
### Motivation
- Add optional Quran Foundation Content and User API integration to enable server-powered ayah search and user bookmark sync while preserving the local-first editor experience.
- Provide a small sync/queue mechanism so bookmarks can be persisted locally and later pushed to the Quran Foundation User API when credentials are available.
- Surface sync status and controls in the UI to make the connected workflow discoverable and demonstrable for hackathon/eligibility requirements.

### Description
- Added environment flags and credentials to `.env.template` (`VITE_USE_QF_CONTENT_API`, `VITE_QF_CLIENT_ID`, `VITE_QF_CLIENT_SECRET`, `VITE_QF_ENDPOINT`) and documented a "hackathon mode" in `README.md` for enabling QF integration.  
- Implemented a new `src/lib/quran-foundation.ts` module that wraps remote verse search (`searchQuranFoundationVerses`) and a feature flag helper (`shouldUseQfContentApi`).
- Implemented a new `src/lib/qf-sync.ts` module providing a sync queue, `enqueueBookmarkSync`, `flushSyncQueue`, and `hasUserApiCredentials` for pushing bookmarks to the User API.  
- Extended the local Dexie schema in `src/lib/db.ts` with `verseBookmarks` and `syncQueue` tables and exported new types (`VerseBookmark`, `SyncQueueItem`).
- Enhanced the inline slash command UI in `src/components/ui/slash-node.tsx` to combine local verses with remote Content API results, show source labels, and allow bookmarking via a `BookmarkPlus` button that stores local bookmarks and enqueues remote sync.
- Added `src/components/SyncStatusBadge.tsx` to display pending/failed queue counts and a manual `flushSyncQueue` button, and integrated it into the `Sidebar` UI.
- Added a project doc `docs/quran-hackathon-gap-analysis.md` outlining requirements and recommended integration plan for the hackathon.

### Testing
- Built the project and type-checked the code with a production build via `npm run build`, and the build completed successfully.  
- Exercised the new Dexie migrations and sync queue flow in a local dev smoke run which completed without runtime errors when `VITE_USE_QF_CONTENT_API` was toggled off (local-only mode).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef63f81d10832590eedbe5d776ffee)