### PR TITLE
Integrate Quran Foundation API: verse details modal, bookmarking, and env variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,5 @@
 VITE_DATA_URL=
+VITE_QF_CLIENT_ID=
+VITE_QF_CLIENT_SECRET=
+VITE_QF_AUTH_BASE_URL=https://prelive-oauth2.quran.foundation
+VITE_QF_API_BASE_URL=https://apis-prelive.quran.foundation

--- a/src/components/VerseDetailsModal.tsx
+++ b/src/components/VerseDetailsModal.tsx
@@ -1,0 +1,68 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { VerseRef } from "@/lib/qf-api";
+
+type VerseDetailsModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  verse: VerseRef | null;
+  details: any;
+  loading: boolean;
+  error: string | null;
+  onBookmark: () => Promise<void>;
+};
+
+export function VerseDetailsModal({
+  open,
+  onOpenChange,
+  verse,
+  details,
+  loading,
+  error,
+  onBookmark,
+}: VerseDetailsModalProps) {
+  const translation = details?.translations?.translations?.[0];
+  const tafsir = details?.tafsir?.tafsirs?.[0];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent dir="rtl" className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            {verse ? `${verse.surah} ${verse.ayah} (${verse.verseKey})` : "تفاصيل الآية"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {loading && <p className="text-sm text-muted-foreground">جاري تحميل التفسير والترجمة والصوت...</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        {!loading && !error && verse && (
+          <div className="space-y-4">
+            {verse.text && <p className="text-xl leading-9">﴿{verse.text}﴾</p>}
+
+            <section>
+              <h4 className="font-semibold mb-1">الترجمة</h4>
+              <p className="text-sm leading-7">{translation?.text ?? "لا توجد ترجمة متاحة"}</p>
+            </section>
+
+            <section>
+              <h4 className="font-semibold mb-1">التفسير</h4>
+              <p className="text-sm leading-7 max-h-40 overflow-auto">{tafsir?.text ?? "لا يوجد تفسير متاح"}</p>
+            </section>
+
+            <section>
+              <h4 className="font-semibold mb-1">الصوت</h4>
+              <audio controls className="w-full">
+                <source src={details?.audio?.audio_file?.audio_url ?? ""} />
+              </audio>
+            </section>
+
+            <div className="flex justify-end">
+              <Button onClick={() => void onBookmark()}>إضافة إلى Bookmarks</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -20,6 +20,8 @@ import { editorPlugins } from "@/constants/editor";
 import { db } from "@/lib/db";
 import { useParams } from "react-router-dom";
 import { useEffect, useState, useCallback, useRef } from "react";
+import { VerseDetailsModal } from "@/components/VerseDetailsModal";
+import { createBookmark, fetchVerseContent, type VerseRef } from "@/lib/qf-api";
 import { FileText, Download, SquarePen } from "lucide-react";
 import { SaveStatus, type SaveState } from "@/components/SaveStatus";
 import { exportToJSON, exportToHTML, exportToMarkdown, exportToPDF } from "@/lib/utils/export";
@@ -31,6 +33,11 @@ export default function SideBar() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState("");
   const { id } = useParams();
+  const [selectedVerse, setSelectedVerse] = useState<VerseRef | null>(null);
+  const [verseModalOpen, setVerseModalOpen] = useState(false);
+  const [verseDetails, setVerseDetails] = useState<any>(null);
+  const [verseLoading, setVerseLoading] = useState(false);
+  const [verseError, setVerseError] = useState<string | null>(null);
   const editor = usePlateEditor({
     plugins: editorPlugins,
     value: [],
@@ -145,6 +152,55 @@ export default function SideBar() {
     fetchPage();
   }, [id]);
 
+  const parseVerseFromText = (text: string): VerseRef | null => {
+    const metaMatch = text.match(/\[([^\]]+)\s+(\d+)\]/);
+    const verseTextMatch = text.match(/﴿([^﴾]+)﴾/);
+    if (!metaMatch) return null;
+
+    const surah = metaMatch[1]?.trim();
+    const ayah = Number(metaMatch[2]);
+    if (!surah || Number.isNaN(ayah)) return null;
+
+    return {
+      surah,
+      ayah,
+      verseKey: `${surah}:${ayah}`,
+      text: verseTextMatch?.[1]?.trim(),
+    };
+  };
+
+  const handleEditorClick = async () => {
+    const sel = window.getSelection();
+    const rawText = sel?.anchorNode?.textContent ?? "";
+    const verse = parseVerseFromText(rawText);
+    if (!verse) return;
+
+    setSelectedVerse(verse);
+    setVerseModalOpen(true);
+    setVerseLoading(true);
+    setVerseError(null);
+
+    try {
+      const details = await fetchVerseContent(verse);
+      setVerseDetails(details);
+    } catch (e) {
+      setVerseError("تعذر جلب بيانات الآية من Quran Foundation APIs");
+    } finally {
+      setVerseLoading(false);
+    }
+  };
+
+  const handleBookmark = async () => {
+    if (!selectedVerse) return;
+    try {
+      await createBookmark(selectedVerse);
+      toast.success("تم حفظ الآية في Bookmarks");
+    } catch (e) {
+      toast.error("فشل حفظ Bookmark");
+    }
+  };
+
+
   return (
     <div className="editor-container">
       <SidebarProvider>
@@ -235,6 +291,7 @@ export default function SideBar() {
             </div>
           </header>
 
+          <div onClick={() => void handleEditorClick()}>
           <EditorLayout
             editor={editor}
             className="font-['Amiri'] overflow-hidden"
@@ -243,6 +300,16 @@ export default function SideBar() {
                 debouncedSave(savePage);
               }
             }}
+          />
+          </div>
+          <VerseDetailsModal
+            open={verseModalOpen}
+            onOpenChange={setVerseModalOpen}
+            verse={selectedVerse}
+            details={verseDetails}
+            loading={verseLoading}
+            error={verseError}
+            onBookmark={handleBookmark}
           />
         </SidebarInset>
         <Toaster

--- a/src/lib/qf-api.ts
+++ b/src/lib/qf-api.ts
@@ -1,0 +1,88 @@
+export type VerseRef = {
+  surah: string;
+  ayah: number;
+  verseKey: string;
+  text?: string;
+};
+
+type TokenCache = {
+  accessToken: string;
+  expiresAt: number;
+} | null;
+
+let tokenCache: TokenCache = null;
+
+const getEnv = (key: string, fallback = "") =>
+  (import.meta.env[key] as string | undefined) ?? fallback;
+
+const API_BASE_URL = getEnv("VITE_QF_API_BASE_URL", "https://apis-prelive.quran.foundation");
+const AUTH_BASE_URL = getEnv("VITE_QF_AUTH_BASE_URL", "https://prelive-oauth2.quran.foundation");
+const CLIENT_ID = getEnv("VITE_QF_CLIENT_ID");
+const CLIENT_SECRET = getEnv("VITE_QF_CLIENT_SECRET");
+
+async function getAccessToken() {
+  if (tokenCache && Date.now() < tokenCache.expiresAt) return tokenCache.accessToken;
+  if (!CLIENT_ID || !CLIENT_SECRET) {
+    throw new Error("QF credentials are missing. Set VITE_QF_CLIENT_ID and VITE_QF_CLIENT_SECRET.");
+  }
+
+  const resp = await fetch(`${AUTH_BASE_URL}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "client_credentials",
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+    }),
+  });
+
+  if (!resp.ok) throw new Error("Failed to authenticate with Quran Foundation APIs");
+  const data = await resp.json();
+  tokenCache = {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + (Number(data.expires_in) - 30) * 1000,
+  };
+  return tokenCache.accessToken;
+}
+
+async function qfGet(path: string) {
+  const token = await getAccessToken();
+  const resp = await fetch(`${API_BASE_URL}${path}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) throw new Error(`QF API error (${resp.status})`);
+  return resp.json();
+}
+
+export async function fetchVerseContent(verse: VerseRef) {
+  const [translations, tafsir, audio] = await Promise.allSettled([
+    qfGet(`/content/api/v4/verses/by_key/${verse.verseKey}/translations?language=en`),
+    qfGet(`/content/api/v4/verses/by_key/${verse.verseKey}/tafsirs`),
+    qfGet(`/content/api/v4/chapter_recitations/7/${verse.verseKey.split(":")[0]}`),
+  ]);
+
+  return {
+    translations: translations.status === "fulfilled" ? translations.value : null,
+    tafsir: tafsir.status === "fulfilled" ? tafsir.value : null,
+    audio: audio.status === "fulfilled" ? audio.value : null,
+  };
+}
+
+export async function createBookmark(verse: VerseRef) {
+  const token = await getAccessToken();
+  const resp = await fetch(`${API_BASE_URL}/user/api/v1/bookmarks`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      key: verse.verseKey,
+      notes: "Saved from Kamil editor",
+      folder_name: "Kamil Hackathon",
+    }),
+  });
+
+  if (!resp.ok) throw new Error(`Bookmark API error (${resp.status})`);
+  return resp.json();
+}


### PR DESCRIPTION
### Motivation
- Provide a way to select a verse inside the editor and fetch its translation, tafsir, and audio from Quran Foundation APIs. 
- Allow users to view verse details in a modal and save bookmarks to the Quran Foundation user bookmarks endpoint. 
- Centralize API authentication and calls with client-credentials flow and token caching. 

### Description
- Added `src/lib/qf-api.ts` which implements token management (`getAccessToken`), `qfGet`, `fetchVerseContent`, and `createBookmark` using `VITE_QF_*` env variables. 
- Introduced `src/components/VerseDetailsModal.tsx` to display Arabic verse text, translation, tafsir, audio, error/loading states, and a bookmark action. 
- Integrated selection parsing and modal flow into `src/layout/Sidebar.tsx` by adding `parseVerseFromText`, `handleEditorClick`, `handleBookmark`, state hooks, modal wiring, and wrapping `EditorLayout` with a click handler to trigger fetches. 
- Updated `.env.template` to include `VITE_QF_CLIENT_ID`, `VITE_QF_CLIENT_SECRET`, `VITE_QF_AUTH_BASE_URL`, and `VITE_QF_API_BASE_URL` with sane prelive defaults. 

### Testing
- Ran the existing test suite with `npm test` and the tests completed successfully. 
- Performed a full project build with `npm run build` to validate TypeScript compilation and there were no build errors. 
- Ran linter checks with `npm run lint` and there were no linting failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015654dc1c8325bddb78980c308bf7)