### PR TITLE
Integrate Quran Foundation API: verse details modal, bookmarks, and editor markers

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,6 @@
 VITE_DATA_URL=
+VITE_QF_CLIENT_ID=
+VITE_QF_CLIENT_SECRET=
+VITE_QF_USER_ACCESS_TOKEN=
+VITE_QF_AUTH_BASE_URL=https://prelive-oauth2.quran.foundation
+VITE_QF_API_BASE_URL=https://apis-prelive.quran.foundation

--- a/src/components/VerseDetailsModal.tsx
+++ b/src/components/VerseDetailsModal.tsx
@@ -1,0 +1,70 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { VerseRef } from "@/lib/qf-api";
+
+type VerseDetailsModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  verse: VerseRef | null;
+  details: any;
+  loading: boolean;
+  error: string | null;
+  onBookmark: () => Promise<void>;
+};
+
+export function VerseDetailsModal({
+  open,
+  onOpenChange,
+  verse,
+  details,
+  loading,
+  error,
+  onBookmark,
+}: VerseDetailsModalProps) {
+  const translation = details?.translations?.translations?.[0] ?? details?.translations?.translation;
+  const tafsir = details?.tafsir?.tafsirs?.[0] ?? details?.tafsir?.tafsir;
+  const verseText = details?.verse?.text_uthmani ?? verse?.text;
+  const audioUrl = details?.audio?.audio_file?.url ?? details?.audio?.audio_file?.audio_url ?? details?.audio?.audio_url;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent dir="rtl" className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>
+            {verse ? `${verse.surah} ${verse.ayah} (${verse.verseKey})` : "تفاصيل الآية"}
+          </DialogTitle>
+        </DialogHeader>
+
+        {loading && <p className="text-sm text-muted-foreground">جاري تحميل التفسير والترجمة والصوت...</p>}
+        {error && <p className="text-sm text-red-600">{error}</p>}
+
+        {!loading && !error && verse && (
+          <div className="space-y-4">
+            {verseText && <p className="text-xl leading-9">﴿{verseText}﴾</p>}
+
+            <section>
+              <h4 className="font-semibold mb-1">الترجمة</h4>
+              <p className="text-sm leading-7">{translation?.text ?? "لا توجد ترجمة متاحة"}</p>
+            </section>
+
+            <section>
+              <h4 className="font-semibold mb-1">التفسير</h4>
+              <p className="text-sm leading-7 max-h-40 overflow-auto">{tafsir?.text ?? "لا يوجد تفسير متاح"}</p>
+            </section>
+
+            <section>
+              <h4 className="font-semibold mb-1">الصوت</h4>
+              <audio controls className="w-full">
+                <source src={audioUrl ?? ""} />
+              </audio>
+            </section>
+
+            <div className="flex justify-end">
+              <Button onClick={() => void onBookmark()}>إضافة إلى Bookmarks</Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/ui/slash-node.tsx
+++ b/src/components/ui/slash-node.tsx
@@ -16,6 +16,7 @@ import {
 import { KEYS } from "platejs";
 
 type Group = {
+  chapterId: number;
   id: number;
   surah: string;
   aya: number;
@@ -49,17 +50,29 @@ interface Aya {
   textTashkeel: string;
 }
 
-const groups: Group[] = quran.map((item: Aya) => ({
+const surahToChapterId = new Map<string, number>();
+let chapterCounter = 0;
+
+const groups: Group[] = quran.map((item: Aya) => {
+  if (!surahToChapterId.has(item.surah)) {
+    chapterCounter += 1;
+    surahToChapterId.set(item.surah, chapterCounter);
+  }
+  const chapterId = surahToChapterId.get(item.surah)!;
+
+  return ({
   ...item,
+  chapterId,
   onSelect: (editor: PlateEditor, value: string, color = "#16a34a") => {
     const fontSize = editor.api.marks()?.[KEYS.fontSize];
     editor.tf.addMarks({ color });
     editor.tf.addMarks({ fontSize });
-    editor.tf.insertText(` ﴿${value}﴾ [${item.surah} ${item.aya}] `);
+    editor.tf.insertText(` ﴿${value}﴾ [${item.surah} ${item.aya}]<${chapterId}:${item.aya}> `);
     editor.tf.removeMark("color");
 
   },
-}));
+  });
+});
 
 
 

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -20,6 +20,8 @@ import { editorPlugins } from "@/constants/editor";
 import { db } from "@/lib/db";
 import { useParams } from "react-router-dom";
 import { useEffect, useState, useCallback, useRef } from "react";
+import { VerseDetailsModal } from "@/components/VerseDetailsModal";
+import { createBookmark, fetchVerseContent, type VerseRef } from "@/lib/qf-api";
 import { FileText, Download, SquarePen } from "lucide-react";
 import { SaveStatus, type SaveState } from "@/components/SaveStatus";
 import { exportToJSON, exportToHTML, exportToMarkdown, exportToPDF } from "@/lib/utils/export";
@@ -31,6 +33,11 @@ export default function SideBar() {
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [titleValue, setTitleValue] = useState("");
   const { id } = useParams();
+  const [selectedVerse, setSelectedVerse] = useState<VerseRef | null>(null);
+  const [verseModalOpen, setVerseModalOpen] = useState(false);
+  const [verseDetails, setVerseDetails] = useState<any>(null);
+  const [verseLoading, setVerseLoading] = useState(false);
+  const [verseError, setVerseError] = useState<string | null>(null);
   const editor = usePlateEditor({
     plugins: editorPlugins,
     value: [],
@@ -145,6 +152,58 @@ export default function SideBar() {
     fetchPage();
   }, [id]);
 
+  const parseVerseFromText = (text: string): VerseRef | null => {
+    const metaMatch = text.match(/\[([^\]]+)\s+(\d+)\]/);
+    const verseTextMatch = text.match(/﴿([^﴾]+)﴾/);
+    const keyMatch = text.match(/<(\d+:\d+)>/);
+    if (!metaMatch) return null;
+
+    const surah = metaMatch[1]?.trim();
+    const ayah = Number(metaMatch[2]);
+    if (!surah || Number.isNaN(ayah)) return null;
+
+    return {
+      surah,
+      ayah,
+      verseKey: keyMatch?.[1] ?? "",
+      text: verseTextMatch?.[1]?.trim(),
+    };
+  };
+
+  const handleEditorClick = async () => {
+    const sel = window.getSelection();
+    const rawText = sel?.anchorNode?.textContent ?? "";
+    const verse = parseVerseFromText(rawText);
+    if (!verse) return;
+
+    setSelectedVerse(verse);
+    setVerseModalOpen(true);
+    setVerseLoading(true);
+    setVerseError(null);
+
+    try {
+      if (!verse.verseKey) throw new Error("Missing verse key marker");
+      const details = await fetchVerseContent(verse.verseKey);
+      setSelectedVerse(verse);
+      setVerseDetails(details);
+    } catch (e) {
+      setVerseError("تعذر جلب بيانات الآية من Quran Foundation APIs");
+    } finally {
+      setVerseLoading(false);
+    }
+  };
+
+  const handleBookmark = async () => {
+    if (!selectedVerse) return;
+    try {
+      await createBookmark(selectedVerse.verseKey);
+      toast.success("تم حفظ الآية في Bookmarks");
+    } catch (e) {
+      toast.error("فشل حفظ Bookmark");
+    }
+  };
+
+
   return (
     <div className="editor-container">
       <SidebarProvider>
@@ -235,6 +294,7 @@ export default function SideBar() {
             </div>
           </header>
 
+          <div onClick={() => void handleEditorClick()}>
           <EditorLayout
             editor={editor}
             className="font-['Amiri'] overflow-hidden"
@@ -243,6 +303,16 @@ export default function SideBar() {
                 debouncedSave(savePage);
               }
             }}
+          />
+          </div>
+          <VerseDetailsModal
+            open={verseModalOpen}
+            onOpenChange={setVerseModalOpen}
+            verse={selectedVerse}
+            details={verseDetails}
+            loading={verseLoading}
+            error={verseError}
+            onBookmark={handleBookmark}
           />
         </SidebarInset>
         <Toaster

--- a/src/lib/qf-api.ts
+++ b/src/lib/qf-api.ts
@@ -1,0 +1,78 @@
+export type VerseRef = {
+  surah: string;
+  ayah: number;
+  verseKey: string;
+  text?: string;
+};
+
+type TokenCache = {
+  accessToken: string;
+  expiresAt: number;
+} | null;
+
+let tokenCache: TokenCache = null;
+
+const getEnv = (key: string, fallback = "") =>
+  (import.meta.env[key] as string | undefined) ?? fallback;
+
+const API_BASE_URL = getEnv("VITE_QF_API_BASE_URL", "https://apis-prelive.quran.foundation");
+const AUTH_BASE_URL = getEnv("VITE_QF_AUTH_BASE_URL", "https://prelive-oauth2.quran.foundation");
+const CLIENT_ID = getEnv("VITE_QF_CLIENT_ID");
+const CLIENT_SECRET = getEnv("VITE_QF_CLIENT_SECRET");
+const USER_ACCESS_TOKEN = getEnv("VITE_QF_USER_ACCESS_TOKEN");
+
+async function getClientAccessToken() {
+  if (tokenCache && Date.now() < tokenCache.expiresAt) return tokenCache.accessToken;
+  if (!CLIENT_ID || !CLIENT_SECRET) throw new Error("Missing QF client credentials.");
+
+  const resp = await fetch(`${AUTH_BASE_URL}/oauth2/token`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({ grant_type: "client_credentials", client_id: CLIENT_ID, client_secret: CLIENT_SECRET }),
+  });
+  if (!resp.ok) throw new Error(`Auth failed (${resp.status})`);
+
+  const data = await resp.json();
+  tokenCache = {
+    accessToken: data.access_token,
+    expiresAt: Date.now() + (Number(data.expires_in || 3600) - 30) * 1000,
+  };
+  return tokenCache.accessToken;
+}
+
+async function qfGet(path: string) {
+  const token = await getClientAccessToken();
+  const resp = await fetch(`${API_BASE_URL}${path}`, { headers: { Authorization: `Bearer ${token}` } });
+  if (!resp.ok) throw new Error(`QF API error (${resp.status}) for ${path}`);
+  return resp.json();
+}
+
+export async function fetchVerseContent(verseKey: string) {
+  const verse = await qfGet(`/content/api/v4/verses/by_key/${verseKey}`);
+  const [translations, tafsir, recitation] = await Promise.allSettled([
+    qfGet(`/content/api/v4/verses/by_key/${verseKey}/translations?translations=131`),
+    qfGet(`/content/api/v4/verses/by_key/${verseKey}/tafsirs?tafsirs=169`),
+    qfGet(`/content/api/v4/recitations/7/by_ayah/${verseKey}`),
+  ]);
+
+  return {
+    verse: verse?.verse ?? null,
+    translations: translations.status === "fulfilled" ? translations.value : null,
+    tafsir: tafsir.status === "fulfilled" ? tafsir.value : null,
+    audio: recitation.status === "fulfilled" ? recitation.value : null,
+  };
+}
+
+export async function createBookmark(verseKey: string) {
+  const token = USER_ACCESS_TOKEN || (await getClientAccessToken());
+  const resp = await fetch(`${API_BASE_URL}/user/api/v1/bookmarks`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ key: verseKey }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`Bookmark API error (${resp.status}): ${body}`);
+  }
+  return resp.json();
+}


### PR DESCRIPTION
### Motivation
- Provide per-verse details (translation, tafsir, audio) and bookmarking using Quran Foundation APIs from selected editor content.
- Persist a light-weight verse marker in editor text so verse lookups can be resolved later.
- Expose configurable QF endpoints and credentials via environment variables.

### Description
- Added a new API client `src/lib/qf-api.ts` with `fetchVerseContent` and `createBookmark`, plus client credentials/token caching and auth flow using `VITE_QF_*` env vars.
- Introduced `VerseDetailsModal` component (`src/components/VerseDetailsModal.tsx`) to display verse text, translation, tafsir, audio and a bookmark action.
- Wired up the editor UI in `src/layout/Sidebar.tsx` to parse verse markers from selected text, open the modal on click, fetch verse details via `fetchVerseContent`, and call `createBookmark` for saving bookmarks.
- Updated the inline slash node (`src/components/ui/slash-node.tsx`) to assign a `chapterId` per surah and insert a stable marker `<chapterId:ayah>` into inserted verse text for later parsing.
- Added new environment entries to `.env.template`: `VITE_QF_CLIENT_ID`, `VITE_QF_CLIENT_SECRET`, `VITE_QF_USER_ACCESS_TOKEN`, `VITE_QF_AUTH_BASE_URL`, and `VITE_QF_API_BASE_URL`.

### Testing
- Ran TypeScript type checking with `tsc --noEmit` which completed successfully.
- Performed a production build with `vite build` which completed successfully.
- No failing automated tests were produced by the build/typecheck steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a015654dc1c8325bddb78980c308bf7)