### PR TITLE
Handle Quran API failures more gracefully

### DIFF
--- a/src/lib/qf/api.ts
+++ b/src/lib/qf/api.ts
@@ -11,6 +11,7 @@ const USER_API = `${API_BASE_URL}/auth/v1`;
 
 let contentToken: string | null = null;
 let contentTokenPromise: Promise<string | null> | null = null;
+const hadithRequestBlocklist = new Set<string>();
 
 async function ensureContentToken(): Promise<string | null> {
   if (contentToken) return contentToken;
@@ -320,18 +321,33 @@ export async function fetchVerseDetails(verseKey: string): Promise<VerseDetails>
 }
 
 export async function fetchHadithsByAyah(ayahKey: string): Promise<Hadith[]> {
+  if (hadithRequestBlocklist.has(ayahKey)) return [];
+
   const headers = await getAuthHeaders();
+  const params = new URLSearchParams({ language: "ar", per_page: "5" });
+  const controller = new AbortController();
+  const timeout = window.setTimeout(() => controller.abort(), 6000);
+
   try {
-    const params = new URLSearchParams({ language: "ar", per_page: "5" });
     const response = await fetch(
       `${CONTENT_API}/hadith_references/by_ayah/${ayahKey}/hadiths?${params}`,
-      { headers }
+      { headers, signal: controller.signal }
     );
-    if (!response.ok) return [];
+
+    if (!response.ok) {
+      if ([429, 500, 502, 503, 504].includes(response.status)) {
+        hadithRequestBlocklist.add(ayahKey);
+      }
+      return [];
+    }
+
     const data = await response.json();
     return data.hadiths || [];
   } catch {
+    hadithRequestBlocklist.add(ayahKey);
     return [];
+  } finally {
+    window.clearTimeout(timeout);
   }
 }
 
@@ -570,6 +586,9 @@ async function userApiFetch<T>(path: string, options?: RequestInit): Promise<T> 
   const response = await fetch(url, { ...options, headers });
 
   if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      localStorage.removeItem("qf_tokens");
+    }
     const err = await response.json().catch(() => ({}));
     throw new Error(err.message || err.error?.message || `User API error: ${response.status}`);
   }


### PR DESCRIPTION
### Motivation
- Reduce repeated noisy failing requests to the Quran Foundation content endpoints that were causing UI stalls and repeated console `403`/`504` errors.
- Avoid retrying hadith-by-ayah lookups for the same ayah within a session and recover cleanly from stale authentication that produces `401/403` responses.

### Description
- Added an in-memory `hadithRequestBlocklist` (`Set<string>`) to short-circuit further hadith lookups for ayah keys that recently experienced transient upstream failures in `src/lib/qf/api.ts`.
- Added a 6-second request timeout using `AbortController` to `fetchHadithsByAyah` so hadith requests fail fast instead of blocking the UI on slow gateway responses.
- Mark ayah keys in the blocklist when requests return `429`/`5xx` responses or when the fetch throws, and immediately return an empty array for blocklisted keys.
- Improved `userApiFetch` error handling to clear stored tokens from `localStorage` on `401`/`403` responses to prevent repeated forbidden calls with stale credentials.

### Testing
- Ran `npm run -s build`, which failed in this environment due to existing TypeScript/dependency configuration issues unrelated to these changes (deprecation and missing dev typings/plugins), so no successful full build verification was possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b7f4a9a88325bfd1ee17b0434383)