### PR TITLE
Add AI chat integration (OpenRouter + AI SDK + MCP) with UI and editor insertion

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -11,3 +11,13 @@ VITE_REDIRECT_URI=
 
 # ─── Offline Quran Data ────────────────────────────────────────────
 VITE_DATA_URL=
+
+# ─── AI Chat (OpenRouter + AI SDK + MCP) ───────────────────────────
+# Server-side key used by /api/chat (do NOT prefix with VITE_)
+OPENROUTER_API_KEY=
+# Example model: openai/gpt-4.1-mini, anthropic/claude-3.5-sonnet
+OPENROUTER_MODEL=openai/gpt-4.1-mini
+
+# MCP endpoints used by the tool adapters in src/lib/ai/mcp.ts
+QURAN_MCP_URL=https://mcp.quran.ai
+HADITH_MCP_URL=https://hadith-mcp.org

--- a/api/chat.ts
+++ b/api/chat.ts
@@ -1,0 +1,26 @@
+import { streamText, convertToModelMessages } from "ai";
+import { openrouter, DEFAULT_OPENROUTER_MODEL } from "../src/lib/ai/openrouter";
+import { hadithSearchTool, quranSearchTool } from "../src/lib/ai/tools";
+
+export const maxDuration = 60;
+
+export default async function handler(req: Request) {
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", { status: 405 });
+  }
+
+  const body = await req.json();
+
+  const result = streamText({
+    model: openrouter(DEFAULT_OPENROUTER_MODEL),
+    system:
+      "You are a Quran/Hadith writing assistant. For factual religious content, use tools first and cite retrieved evidence. If no tool data, explicitly say source unavailable.",
+    messages: convertToModelMessages(body.messages || []),
+    tools: {
+      search_quran_mcp: quranSearchTool,
+      search_hadith_mcp: hadithSearchTool,
+    },
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/docs/ai-chat-integration-plan.md
+++ b/docs/ai-chat-integration-plan.md
@@ -1,0 +1,175 @@
+# AI Chat Integration Plan (OpenRouter + AI SDK + MCP Quran/Hadith)
+
+## 1) External docs analysis
+
+### AI SDK (Vercel)
+- AI SDK gives a provider-agnostic interface for chat streaming (`streamText`) and UI helpers (`useChat`).
+- It supports multi-step tools, which is essential for MCP-style retrieval workflows.
+- It is TypeScript-first and fits the current React/Vite codebase.
+
+### OpenRouter + Vercel AI SDK
+- OpenRouter officially supports AI SDK via `@openrouter/ai-sdk-provider`.
+- Recommended setup is creating an OpenRouter provider with `createOpenRouter({ apiKey })` and using AI SDK calls with `openrouter(modelName)`.
+- This gives model routing flexibility while keeping a stable SDK surface in app code.
+
+### hadith-mcp.org
+- Exposes retrieval tools for hadith grounding, including:
+  - `search_hadith`
+  - `fetch_hadith`
+  - `list_collections`
+  - `fetch_grounding_rules`
+- Includes collection/book/hadith metadata and Arabic/English content.
+- Good fit for citation-first retrieval instead of free-form generation.
+
+### mcp.quran.ai
+- Provides canonical Quran retrieval (text, translations, tafsir) via MCP.
+- Supports semantic search and rich metadata across ayah data.
+- Good fit for exact verse insertion and evidence-grounded answers.
+
+## 2) Current codebase analysis
+
+## Stack and architecture
+- Frontend app: React + Vite + TypeScript. (`package.json`)
+- Rich editor: PlateJS already deeply integrated. (`src/components/editor/*`, `src/components/ui/editor.tsx`)
+- Domain integrations already exist:
+  - Quran APIs and auth flow in `src/lib/qf/api.ts`.
+  - Hadith APIs in `src/lib/hadith/api.ts`.
+- UI has side panels and insertion affordances for Quran/Hadith:
+  - Verse panel with rich details and `insert-hadith` event emission path. (`src/components/VersePanel.tsx`)
+  - Hadith details panel. (`src/components/HadithPanel.tsx`)
+
+## Existing insertion pattern (important for AI feature)
+- The app already inserts structured religious content through custom editor flows/events.
+- This means AI chat can re-use an existing “insert into editor” interaction model instead of inventing one.
+
+## Gap analysis for requested feature
+- No AI chat runtime yet (no dedicated `/api/chat`, no AI SDK hooks currently wired for chat UI).
+- No OpenRouter provider wiring yet.
+- No MCP client bridge yet for Quran/Hadith retrieval during chat turns.
+
+## 3) Target integration design
+
+## Objectives
+1. Add AI chat based on AI SDK components.
+2. Use OpenRouter as model provider.
+3. Use MCP-backed retrieval for Quran/Hadith instead of ungrounded answers.
+4. Allow one-click insertion of verse/hadith into the editor as native nodes.
+
+## Proposed high-level flow
+1. User asks in Chat Panel.
+2. AI SDK `useChat` sends message to backend chat endpoint.
+3. Backend calls `streamText` with OpenRouter model.
+4. Model can call two tools:
+   - `search_quran_mcp`
+   - `search_hadith_mcp`
+5. Tool handlers query MCP servers (`https://mcp.quran.ai`, `https://hadith-mcp.org`) and return normalized evidence objects.
+6. Assistant answer renders with citations + action chips:
+   - Insert verse
+   - Insert hadith
+7. Clicking insert emits app event that editor consumes to insert structured node.
+
+## Data contracts (normalized)
+
+### VerseEvidence
+- `source: "quran_mcp"`
+- `verseKey`
+- `arabicText`
+- `translation?`
+- `surahName?`
+- `ayahNumber?`
+- `citation` (server/tool/ref)
+
+### HadithEvidence
+- `source: "hadith_mcp"`
+- `collection`
+- `bookNumber?`
+- `hadithNumber`
+- `arabicText`
+- `englishText?`
+- `grades?`
+- `citation`
+
+These contracts should be the only payload used by UI insertion actions.
+
+## 4) Implementation plan (phased)
+
+## Phase 0 — foundation
+- Add dependencies:
+  - `ai`
+  - `@openrouter/ai-sdk-provider`
+  - MCP client transport package chosen for browser/server boundary.
+- Add env vars:
+  - `OPENROUTER_API_KEY`
+  - `OPENROUTER_MODEL` (default fallback)
+  - `QURAN_MCP_URL=https://mcp.quran.ai`
+  - `HADITH_MCP_URL=https://hadith-mcp.org`
+
+## Phase 1 — chat backend service
+- Create server endpoint (or edge function) to host AI SDK `streamText`.
+- Initialize OpenRouter provider with strict model allowlist.
+- Register tool definitions (zod schemas) for Quran/Hadith retrieval.
+- Implement tool handlers that call MCP endpoints and map responses to normalized evidence contracts.
+- Add safety behavior:
+  - if tool unavailable, return explicit “source unavailable” message (no fabricated quote).
+
+## Phase 2 — chat frontend
+- Add `ChatPanel` component with AI SDK `useChat`.
+- Render markdown-like response plus a compact “Evidence Cards” section.
+- Each evidence card has:
+  - preview text
+  - source metadata
+  - Insert button
+- Insert button dispatches editor events similar to existing verse/hadith insertion flow.
+
+## Phase 3 — editor insertion integration
+- Reuse or extend current insert event handlers for:
+  - Verse node insertion
+  - Hadith node insertion
+- Ensure payload alignment with node schemas used by existing `verse-kit` and `hadith-kit` plugin stack.
+- Add duplicate-prevention UX (optional toggle “insert as quote block / inline”).
+
+## Phase 4 — grounding, QA, and observability
+- Add “grounding required” system instruction in chat backend:
+  - religious factual answers must cite MCP evidence.
+- Log tool calls (non-PII) for debugging.
+- QA matrix:
+  - Arabic query, English query
+  - direct reference (`2:255`), thematic query
+  - insert verse/hadith success paths
+  - MCP timeout fallback
+
+## 5) Suggested file-level changes
+
+## New files
+- `src/lib/ai/openrouter.ts` — OpenRouter provider + model config.
+- `src/lib/ai/mcp.ts` — MCP client + typed wrappers.
+- `src/lib/ai/tools.ts` — AI SDK tool declarations and adapters.
+- `src/components/chat/ChatPanel.tsx` — chat UI using `useChat`.
+- `src/types/ai-evidence.ts` — normalized contracts.
+
+## Existing files likely to update
+- `src/components/editor/EditorLayout.tsx` — mount ChatPanel in layout.
+- `src/components/editor/EditorContent.tsx` — wire insert events if needed.
+- `src/components/SharedRightPanel.tsx` — optional tab for AI chat.
+- `src/components/editor/plugins/hadith-kit.tsx` and `verse-kit.tsx` — ensure insert command compatibility.
+
+## 6) Risks and mitigations
+- MCP response shape drift
+  - Mitigation: adapter layer + runtime schema validation.
+- Latency from tool calls
+  - Mitigation: stream partial assistant response and render evidence when ready.
+- Hallucinated citations
+  - Mitigation: enforce tool-first policy in system prompt and refuse unsupported claims.
+
+## 7) Delivery order (recommended)
+1. Backend AI SDK + OpenRouter + mock tool responses.
+2. Real MCP tool integration.
+3. Chat UI streaming.
+4. Insert actions into editor.
+5. QA and polishing.
+
+## 8) Acceptance criteria
+- User can chat with an OpenRouter model from inside app UI.
+- Quran/Hadith factual answers are grounded in MCP tool data.
+- User can click Insert on returned verse/hadith and content appears correctly in editor.
+- App gracefully handles MCP downtime without fabricating religious text.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "kamil",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/react": "^1.2.11",
         "@ariakit/react": "^0.4.17",
         "@emoji-mart/data": "^1.2.1",
         "@fontsource/amiri": "^5.2.8",
         "@heroicons/react": "^2.2.0",
         "@nozbe/microfuzz": "^1.0.0",
+        "@openrouter/ai-sdk-provider": "^0.4.5",
         "@platejs/ai": "^49.1.12",
         "@platejs/basic-nodes": "^49.0.0",
         "@platejs/basic-styles": "^49.0.0",
@@ -54,10 +56,12 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-toolbar": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tailwindcss/vite": "^4.1.11",
         "@udecode/cn": "^49.0.15",
+        "ai": "^4.3.16",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -73,7 +77,7 @@
         "jspdf": "^3.0.1",
         "lodash": "^4.17.21",
         "lowlight": "^3.3.0",
-        "lucide-react": "^0.526.0",
+        "lucide-react": "^1.16.0",
         "motion": "^12.23.12",
         "next-themes": "^0.4.6",
         "pdf-lib": "^1.17.1",
@@ -87,6 +91,7 @@
         "react-router-dom": "^7.8.0",
         "react-textarea-autosize": "^8.5.9",
         "react-window": "^1.8.11",
+        "recharts": "3.8.0",
         "remark-gfm": "^4.0.1",
         "remark-math": "^6.0.0",
         "rough-notation": "^0.5.1",
@@ -97,6 +102,7 @@
         "tailwind-scrollbar-hide": "^4.0.0",
         "tailwindcss": "^4.1.11",
         "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.25.76",
         "zustand": "^5.0.6"
       },
       "devDependencies": {
@@ -116,6 +122,94 @@
         "typescript-eslint": "^8.35.1",
         "vite": "^7.0.4",
         "vite-plugin-pwa": "^1.0.2"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.2.8.tgz",
+      "integrity": "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "1.2.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-1.2.12.tgz",
+      "integrity": "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ai-sdk/ui-utils": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/ui-utils/-/ui-utils-1.2.11.tgz",
+      "integrity": "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.23.8"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2376,6 +2470,84 @@
       "version": "1.0.0",
       "license": "MIT"
     },
+    "node_modules/@openrouter/ai-sdk-provider": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-0.4.6.tgz",
+      "integrity": "sha512-oUa8xtssyUhiKEU/aW662lsZ0HUvIUTRk8vVIF3Ha3KI/DnqX54zmVIuzYnaDpermqhy18CHqblAY4dDt1JW3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.0.9",
+        "@ai-sdk/provider-utils": "2.1.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@openrouter/ai-sdk-provider/node_modules/@ai-sdk/provider": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
+      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openrouter/ai-sdk-provider/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
+      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.0.9",
+        "eventsource-parser": "^3.0.0",
+        "nanoid": "^3.3.8",
+        "secure-json-parse": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openrouter/ai-sdk-provider/node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
       "license": "MIT",
@@ -3412,6 +3584,43 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.9",
       "license": "MIT",
@@ -3597,6 +3806,66 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4185,9 +4454,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4200,9 +4466,6 @@
       "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4217,9 +4480,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4232,9 +4492,6 @@
       "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4249,9 +4506,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4264,9 +4518,6 @@
       "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4281,9 +4532,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4296,9 +4544,6 @@
       "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4313,9 +4558,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4328,9 +4570,6 @@
       "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4345,9 +4584,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4361,9 +4597,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4376,9 +4609,6 @@
       "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4463,6 +4693,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -4613,9 +4855,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4632,9 +4871,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4649,9 +4885,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4665,9 +4898,6 @@
       "version": "4.1.11",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4788,12 +5018,81 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/diff-match-patch": {
+      "version": "1.0.36",
+      "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+      "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -4886,6 +5185,12 @@
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5240,6 +5545,32 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "4.3.19",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-4.3.19.tgz",
+      "integrity": "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.1.3",
+        "@ai-sdk/provider-utils": "2.2.8",
+        "@ai-sdk/react": "1.2.12",
+        "@ai-sdk/ui-utils": "1.2.11",
+        "@opentelemetry/api": "1.9.0",
+        "jsondiffpatch": "0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {
@@ -6070,6 +6401,127 @@
       "version": "1.4.5",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dash-video-element": {
       "version": "0.1.6",
       "license": "MIT",
@@ -6178,6 +6630,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.2.0",
@@ -6289,6 +6747,12 @@
         "dexie": "^3.2 || ^4.0.1-alpha",
         "react": ">=16"
       }
+    },
+    "node_modules/diff-match-patch": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+      "license": "Apache-2.0"
     },
     "node_modules/diff-match-patch-ts": {
       "version": "0.6.0",
@@ -6497,6 +6961,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
@@ -6845,6 +7319,21 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -7751,6 +8240,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8388,6 +8886,35 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsondiffpatch": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz",
+      "integrity": "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/diff-match-patch": "^1.0.36",
+        "chalk": "^5.3.0",
+        "diff-match-patch": "^1.0.5"
+      },
+      "bin": {
+        "jsondiffpatch": "bin/jsondiffpatch.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/jsondiffpatch/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "dev": true,
@@ -8605,9 +9132,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8628,9 +9152,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8649,9 +9170,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8669,9 +9187,6 @@
       "version": "1.30.1",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8815,7 +9330,9 @@
       "license": "ISC"
     },
     "node_modules/lucide-react": {
-      "version": "0.526.0",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.16.0.tgz",
+      "integrity": "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10716,6 +11233,116 @@
         "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts/node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/recharts/node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/recharts/node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/recharts/node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/recharts/node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "license": "MIT",
@@ -10969,6 +11596,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "dev": true,
@@ -11139,6 +11772,12 @@
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
       }
+    },
+    "node_modules/secure-json-parse": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.7.0.tgz",
+      "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -11749,6 +12388,28 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/swr/node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "license": "MIT"
@@ -11933,6 +12594,18 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiktok-video-element": {
@@ -12586,6 +13259,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vimeo-video-element": {
       "version": "1.5.3",
       "license": "MIT",
@@ -13102,6 +13797,24 @@
     "node_modules/youtube-video-element": {
       "version": "1.6.1",
       "license": "MIT"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.6",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,11 @@
     "tailwind-scrollbar-hide": "^4.0.0",
     "tailwindcss": "^4.1.11",
     "tailwindcss-animate": "^1.0.7",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "ai": "^4.3.16",
+    "@ai-sdk/react": "^1.2.11",
+    "@openrouter/ai-sdk-provider": "^0.4.5",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",

--- a/src/components/SharedRightPanel.tsx
+++ b/src/components/SharedRightPanel.tsx
@@ -4,10 +4,11 @@ import { useEffect, useState, useRef, useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { VersePanelContent } from "./VersePanel";
 import { HadithPanelContent } from "./HadithPanel";
+import { ChatPanel } from "./chat/ChatPanel";
 
 export function SharedRightPanel() {
   const [open, setOpen] = useState(false);
-  const [activeType, setActiveType] = useState<"verse" | "hadith" | null>(null);
+  const [activeType, setActiveType] = useState<"verse" | "hadith" | "ai" | null>(null);
   const [activeData, setActiveData] = useState<any>(null);
 
   const MIN_WIDTH = 280;
@@ -73,11 +74,19 @@ export function SharedRightPanel() {
       setOpen(true);
     };
 
+    const handleOpenAi = () => {
+      setActiveData(null);
+      setActiveType("ai");
+      setOpen(true);
+    };
+
     window.addEventListener("open-verse-panel", handleOpenVerse);
     window.addEventListener("open-hadith-panel", handleOpenHadith);
+    window.addEventListener("open-ai-chat", handleOpenAi);
     return () => {
       window.removeEventListener("open-verse-panel", handleOpenVerse);
       window.removeEventListener("open-hadith-panel", handleOpenHadith);
+      window.removeEventListener("open-ai-chat", handleOpenAi);
     };
   }, []);
 
@@ -126,6 +135,9 @@ export function SharedRightPanel() {
       )}
       {activeType === "hadith" && activeData && (
         <HadithPanelContent hadithData={activeData} close={close} />
+      )}
+      {activeType === "ai" && (
+        <ChatPanel close={close} />
       )}
     </div>
   );

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,0 +1,65 @@
+import { useMemo } from "react";
+import { useChat } from "@ai-sdk/react";
+import { Button } from "@/components/ui/button";
+
+export function ChatPanel({ close }: { close: () => void }) {
+  const { messages, input, handleInputChange, handleSubmit, status } = useChat({
+    api: "/api/chat",
+  });
+
+  const busy = status === "submitted" || status === "streaming";
+
+  const latestText = useMemo(() => {
+    const last = [...messages].reverse().find((m) => m.role === "assistant");
+    if (!last) return "";
+    return last.parts
+      .filter((p: any) => p.type === "text")
+      .map((p: any) => p.text)
+      .join("\n");
+  }, [messages]);
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="px-4 py-3 border-b flex items-center justify-between">
+        <h3 className="text-sm font-semibold">AI Chat</h3>
+        <Button size="sm" variant="ghost" onClick={close}>إغلاق</Button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-3 space-y-2">
+        {messages.map((message) => (
+          <div key={message.id} className={message.role === "user" ? "text-right" : "text-left"}>
+            <div className="inline-block rounded-md px-3 py-2 text-sm bg-muted">
+              {message.parts.map((part: any, i: number) =>
+                part.type === "text" ? <p key={i}>{part.text}</p> : null
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit} className="p-3 border-t space-y-2">
+        <textarea
+          className="w-full rounded-md border bg-background p-2 text-sm"
+          rows={3}
+          value={input}
+          onChange={handleInputChange}
+          placeholder="اسأل عن آية أو حديث..."
+        />
+        <div className="flex justify-between gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              const verse = latestText.match(/\[(\d+:\d+)\]/)?.[1];
+              if (!verse) return;
+              window.dispatchEvent(new CustomEvent("insert-verse", { detail: { verseKey: verse } }));
+            }}
+          >
+            إدراج آية
+          </Button>
+          <Button type="submit" disabled={busy}>{busy ? "..." : "إرسال"}</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/editor/EditorToolbar.tsx
+++ b/src/components/editor/EditorToolbar.tsx
@@ -1,6 +1,6 @@
 import { MarkToolbarButton } from "@/components/ui/mark-toolbar-button";
 import { AlignToolbarButton } from "@/components/ui/align-toolbar-button";
-import { Bold, Italic, Underline } from "lucide-react";
+import { Bold, Italic, Underline, Bot } from "lucide-react";
 import { FontSizeToolbarButton } from "@/components/ui/font-size-toolbar-button";
 import { ExportDropdown } from "./ExportDropdown";
 
@@ -39,6 +39,18 @@ export function EditorToolbar({ className = "", editor }: EditorToolbarProps) {
 
       <AlignToolbarButton />
       <FontSizeToolbarButton />
+
+
+      <div className="ml-1 border-l border-primary-foreground/10 pl-2">
+        <button
+          type="button"
+          onClick={() => window.dispatchEvent(new CustomEvent("open-ai-chat"))}
+          className="p-1.5 h-9 w-9 inline-flex items-center justify-center rounded-md text-primary-foreground/70 hover:text-primary-foreground hover:bg-primary-foreground/10"
+          title="AI Chat"
+        >
+          <Bot className="w-5 h-5" />
+        </button>
+      </div>
 
       {/* Export */}
       <div className="ml-1 border-l border-primary-foreground/10 pl-2">

--- a/src/layout/Sidebar.tsx
+++ b/src/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import type { SaveState } from "@/components/SaveStatus";
 import { exportToJSON, exportToHTMLAsync, exportToMarkdownAsync, exportToPDF } from "@/lib/utils/export";
 import { debounce } from "@/lib/utils/debounce";
 import { SharedRightPanel } from "@/components/SharedRightPanel";
+import { fetchVerseDetails } from "@/lib/qf/api";
 import { useSidebarState } from "@/hooks/use-sidebar-state";
 
 export default function SideBar() {
@@ -91,6 +92,40 @@ export default function SideBar() {
   }, [pageContent]);
 
   useEffect(() => { fetchPage(); }, [id]);
+
+  // Listen for verse insertion
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const detail = (e as CustomEvent).detail;
+      if (!detail?.verseKey) return;
+
+      let verseText = detail.verseText || "";
+      let surahName = detail.surahName || "";
+      let ayaNumber = detail.ayaNumber || 0;
+
+      if (!verseText) {
+        try {
+          const verse = await fetchVerseDetails(detail.verseKey);
+          verseText = verse.text_uthmani || verse.text_imlaei || "";
+          ayaNumber = Number(detail.verseKey.split(":")[1] || 0);
+        } catch {}
+      }
+
+      editor.tf.insertNodes({
+        type: "verse",
+        verseKey: detail.verseKey,
+        surahName,
+        ayaNumber,
+        verseText,
+        children: [{ text: `﴿${verseText || detail.verseKey}﴾` }],
+      });
+      editor.tf.insertText(" ");
+      editor.tf.move({ distance: 1, unit: "character" });
+    };
+
+    window.addEventListener("insert-verse", handler);
+    return () => window.removeEventListener("insert-verse", handler);
+  }, [editor]);
 
   // Listen for hadith insertion
   useEffect(() => {

--- a/src/lib/ai/mcp.ts
+++ b/src/lib/ai/mcp.ts
@@ -1,0 +1,49 @@
+import type { HadithEvidence, VerseEvidence } from "@/types/ai-evidence";
+
+const QURAN_MCP_URL = process.env.QURAN_MCP_URL || "https://mcp.quran.ai";
+const HADITH_MCP_URL = process.env.HADITH_MCP_URL || "https://hadith-mcp.org";
+
+export async function searchQuranMcp(query: string): Promise<VerseEvidence[]> {
+  const response = await fetch(`${QURAN_MCP_URL}/search`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!response.ok) return [];
+  const json = await response.json();
+  const rows = Array.isArray(json?.verses) ? json.verses : Array.isArray(json?.results) ? json.results : [];
+
+  return rows.slice(0, 5).map((row: any) => ({
+    source: "quran_mcp",
+    verseKey: String(row.verse_key || row.verseKey || ""),
+    arabicText: String(row.arabic || row.text || ""),
+    translation: row.translation ? String(row.translation) : undefined,
+    surahName: row.surah_name ? String(row.surah_name) : undefined,
+    ayahNumber: row.ayah_number ? Number(row.ayah_number) : undefined,
+    citation: `quran_mcp:${row.verse_key || row.verseKey || "unknown"}`,
+  }));
+}
+
+export async function searchHadithMcp(query: string): Promise<HadithEvidence[]> {
+  const response = await fetch(`${HADITH_MCP_URL}/search_hadith`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query }),
+  });
+
+  if (!response.ok) return [];
+  const json = await response.json();
+  const rows = Array.isArray(json?.hadiths) ? json.hadiths : Array.isArray(json?.results) ? json.results : [];
+
+  return rows.slice(0, 5).map((row: any) => ({
+    source: "hadith_mcp",
+    collection: String(row.collection || ""),
+    bookNumber: row.book_number ? String(row.book_number) : undefined,
+    hadithNumber: String(row.hadith_number || row.hadithNumber || ""),
+    arabicText: String(row.arabic || row.text || ""),
+    englishText: row.english ? String(row.english) : undefined,
+    grades: Array.isArray(row.grades) ? row.grades : [],
+    citation: `hadith_mcp:${row.collection || "unknown"}:${row.hadith_number || row.hadithNumber || ""}`,
+  }));
+}

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -1,0 +1,14 @@
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+
+const apiKey = process.env.OPENROUTER_API_KEY;
+
+if (!apiKey) {
+  console.warn("OPENROUTER_API_KEY is not set. AI chat will fail until configured.");
+}
+
+export const openrouter = createOpenRouter({
+  apiKey: apiKey ?? "",
+});
+
+export const DEFAULT_OPENROUTER_MODEL =
+  process.env.OPENROUTER_MODEL || "openai/gpt-4.1-mini";

--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -1,0 +1,21 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { searchHadithMcp, searchQuranMcp } from "./mcp";
+
+export const quranSearchTool = tool({
+  description: "Search the Quran MCP source and return grounded verses",
+  parameters: z.object({ query: z.string().min(1) }),
+  execute: async ({ query }) => {
+    const verses = await searchQuranMcp(query);
+    return { verses };
+  },
+});
+
+export const hadithSearchTool = tool({
+  description: "Search the Hadith MCP source and return grounded hadith references",
+  parameters: z.object({ query: z.string().min(1) }),
+  execute: async ({ query }) => {
+    const hadiths = await searchHadithMcp(query);
+    return { hadiths };
+  },
+});

--- a/src/types/ai-evidence.ts
+++ b/src/types/ai-evidence.ts
@@ -1,0 +1,25 @@
+export interface VerseEvidence {
+  source: "quran_mcp";
+  verseKey: string;
+  arabicText: string;
+  translation?: string;
+  surahName?: string;
+  ayahNumber?: number;
+  citation?: string;
+}
+
+export interface HadithEvidence {
+  source: "hadith_mcp";
+  collection: string;
+  bookNumber?: string;
+  hadithNumber: string;
+  arabicText: string;
+  englishText?: string;
+  grades?: Array<{ graded_by?: string; grade: string }>;
+  citation?: string;
+}
+
+export interface EvidencePayload {
+  verses?: VerseEvidence[];
+  hadiths?: HadithEvidence[];
+}


### PR DESCRIPTION
### Motivation
- Provide a server-backed AI chat assistant that uses OpenRouter via the AI SDK and MCP retrieval tools to ground Quran and Hadith responses.
- Surface a streaming chat UI inside the existing right panel so users can ask questions and insert cited verses/hadith into the editor.
- Add a tool/adaptor layer to call MCP endpoints so answers are evidence-backed and can be mapped into existing editor nodes.

### Description
- Add a streaming backend endpoint at `api/chat.ts` that calls `streamText` with an OpenRouter provider and registers two tools `search_quran_mcp` and `search_hadith_mcp` for grounding. 
- Add AI integration helpers in `src/lib/ai/`: `openrouter.ts` for provider and model config, `mcp.ts` for MCP fetch wrappers, and `tools.ts` for AI SDK tool declarations, plus typed contracts in `src/types/ai-evidence.ts`.
- Add a chat UI component `src/components/chat/ChatPanel.tsx` using `useChat` that streams messages to `/api/chat` and exposes an `إدراج آية` button which dispatches an `insert-verse` event; wire the panel into `SharedRightPanel` and add a toolbar `Bot` button to open the AI tab. 
- Implement editor insertion handling in `src/layout/Sidebar.tsx` to listen for `insert-verse` events and insert `verse` nodes into the editor, update `.env.template` with AI and MCP env vars, add `docs/ai-chat-integration-plan.md`, and update `package.json` and `package-lock.json` to include the AI-related dependencies (`ai`, `@ai-sdk/react`, `@openrouter/ai-sdk-provider`, `zod`, etc.).

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6da92e1c83259bf51ca070e0e415)